### PR TITLE
Fix dark reader being an idiot

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 			name="description"
 			content="A small team of active developers typically focused around finding flaws in methods of ChromeOS user restriction"
 		/>
+		<meta name="darkreader-lock">
 		<link rel="stylesheet" href="/style/style.css" />
 		<title>Mercury Workshop</title>
 		<link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png?k" />


### PR DESCRIPTION
Simple 1 line change to fix the Dark Reader extension from ruining the site.

(Before)
![image](https://github.com/MercuryWorkshop/hg-website/assets/116377025/2f284191-160a-4888-bded-9516b80d6f8c)

(After)
![image](https://github.com/MercuryWorkshop/hg-website/assets/116377025/b099724d-9bc8-45ef-a37c-67c9a42a3f04)
