### PR TITLE
Add cros.download to projects, remove Pollen and Lilac

### DIFF
--- a/src/Projects.ts
+++ b/src/Projects.ts
@@ -72,21 +72,12 @@ export const projects: Project[] = [
 		repo: "https://github.com/MercuryWorkshop/RecoMod",
 	},
 	{
-		name: "Pollen",
+		name: "cros.download",
 		description:
-			"A simple and easy-to-use script for modifying ChromeOS user policies.",
+			"A website providing downloads for ChromeOS recovery images and RMA shims.",
 		longDescription: undefined,
 		screenshotURL: undefined,
-		url: undefined,
-		repo: "https://github.com/MercuryWorkshop/Pollen",
-	},
-	{
-		name: "lilac",
-		description:
-			"A not-so-simple and not-as-easy-to-use script for modifying ChromeOS device policies.",
-		longDescription: undefined,
-		screenshotURL: undefined,
-		url: undefined,
-		repo: "https://github.com/MercuryWorkshop/lilac",
+		url: "https://cros.download/",
+		repo: undefined,
 	},
 ];

--- a/src/pages/ProjectView.tsx
+++ b/src/pages/ProjectView.tsx
@@ -24,16 +24,18 @@ const ProjectView: Component<{ project: Project }, {}> = function () {
 							</a>
 						</p>
 					)}
-					<p>
-						Repository:{" "}
-						<a
-							href={this.project.repo}
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							{this.project.repo}
-						</a>
-					</p>
+					{this.project.repo && (
+						<p>
+							Repository:{" "}
+							<a
+								href={this.project.repo}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{this.project.repo}
+							</a>
+						</p>
+					)}
 				</div>
 			</article>
 		</main>

--- a/src/types/Project.ts
+++ b/src/types/Project.ts
@@ -4,7 +4,7 @@ interface Project {
 	longDescription?: string;
 	screenshotURL?: string;
 	url: string | undefined;
-	repo: string;
+	repo: string | undefined;
 }
 
 export default Project;


### PR DESCRIPTION
This PR adds [cros.download](https://cros.download/) to the website. Pollen and Lilac are removed to give room, because they have not been maintained for years. 

Because cros.download does not yet have a public repository, it is undefined here and only the website is linked. 